### PR TITLE
Auto-publish release workflow (npm + GitHub Releases)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+# Fires when a package version changes on main (a deliberate "release" commit),
+# or on demand. It publishes only the packages whose version is new on npm and
+# creates a GitHub Release for each, so releases appear in the repo sidebar.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - projects/volt/package.json
+      - cli/package.json
+      - cli/mcp/package.json
+  workflow_dispatch:
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+permissions:
+  contents: write # create git tags + GitHub Releases
+
+jobs:
+  release:
+    name: Publish changed packages
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # full history so release notes can diff from the last tag
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Authenticate to npm
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "$HOME/.npmrc"
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Run unit tests
+        run: pnpm test --run
+
+      - name: Build library
+        run: pnpm build:lib
+
+      - name: Publish new versions & create releases
+        run: node scripts/release.mjs
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,56 @@
+# Releasing
+
+Publishing to npm is automated. You bump a version, merge to `main`, and CI
+publishes the changed package(s) and creates a matching GitHub Release.
+
+## How it works
+
+[`.github/workflows/release.yml`](.github/workflows/release.yml) runs when a
+version changes in any publishable `package.json` on `main` (or on manual
+dispatch). It runs the quality gates (lint · typecheck · test · build) and then
+[`scripts/release.mjs`](scripts/release.mjs), which for each package:
+
+1. Compares the local version with the versions already on npm.
+2. If the version is **new**, publishes it (via the existing `publish:*` scripts).
+3. Creates a GitHub Release + git tag so it shows up in the repo sidebar.
+
+The script is **idempotent** — versions already on npm are skipped, so re-running
+never double-publishes.
+
+| Package              | Version source               | npm                                                     | Release tag         |
+| -------------------- | ---------------------------- | ------------------------------------------------------- | ------------------- |
+| `@voltui/components` | `projects/volt/package.json` | [npm](https://www.npmjs.com/package/@voltui/components) | `components-vX.Y.Z` |
+| `@voltui/cli`        | `cli/package.json`           | [npm](https://www.npmjs.com/package/@voltui/cli)        | `cli-vX.Y.Z`        |
+| `volt-ui-mcp`        | `cli/mcp/package.json`       | [npm](https://www.npmjs.com/package/volt-ui-mcp)        | `mcp-vX.Y.Z`        |
+
+## One-time setup: `NPM_TOKEN`
+
+CI needs a token with publish rights:
+
+1. On [npmjs.com](https://www.npmjs.com/) → **Access Tokens** → **Generate New Token** →
+   **Automation** (automation tokens bypass 2FA, which is required for CI).
+2. In GitHub → repo **Settings → Secrets and variables → Actions → New repository secret**:
+   - Name: `NPM_TOKEN`
+   - Value: the token from step 1.
+
+That's the only secret required (`GITHUB_TOKEN` is provided automatically).
+
+## Cutting a release
+
+1. Open a PR that bumps the version of whatever you're releasing, e.g. in
+   `projects/volt/package.json`. Keep [`CHANGELOG.md`](CHANGELOG.md) updated in the
+   same PR.
+2. Merge to `main`.
+3. The **Release** workflow fires, publishes the bumped package(s), and creates the
+   GitHub Release. Independent versions are fine — only the packages you bumped go out.
+
+To publish without a version-file change (e.g. the first run, to push the CLI that's
+currently behind on npm), trigger it manually: **Actions → Release → Run workflow**.
+
+## Preview locally
+
+Read-only check of what would be published (hits npm, publishes nothing):
+
+```bash
+DRY_RUN=1 node scripts/release.mjs
+```

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+/**
+ * Auto-publish release script.
+ *
+ * For each publishable package, compares the version in its package.json with
+ * the versions already on npm. If the local version is new, it:
+ *   1. publishes the package to npm (reusing the existing `publish:*` scripts), and
+ *   2. creates a GitHub Release (which also creates the git tag) so the release
+ *      shows up in the repo's right-hand sidebar.
+ *
+ * It is idempotent: versions already on npm are skipped, so re-running never
+ * double-publishes. Run from CI (`.github/workflows/release.yml`) or locally
+ * with the right credentials (NPM auth in ~/.npmrc and `gh` logged in).
+ *
+ * Env:
+ *   GITHUB_SHA  commit the releases should point at (defaults to HEAD)
+ *   DRY_RUN=1   log what would happen without publishing or creating releases
+ */
+import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+
+const DRY_RUN = process.env.DRY_RUN === '1' || process.argv.includes('--dry-run');
+
+/** Packages published from this repo, in publish order. */
+const PACKAGES = [
+  {
+    name: '@voltui/components',
+    label: 'Components library',
+    versionFile: 'projects/volt/package.json',
+    publish: 'pnpm publish:lib',
+    tagPrefix: 'components',
+  },
+  {
+    name: '@voltui/cli',
+    label: 'CLI',
+    versionFile: 'cli/package.json',
+    publish: 'pnpm publish:cli',
+    tagPrefix: 'cli',
+  },
+  {
+    name: 'volt-ui-mcp',
+    label: 'MCP installer',
+    versionFile: 'cli/mcp/package.json',
+    publish: 'pnpm publish:mcp',
+    tagPrefix: 'mcp',
+  },
+];
+
+const sha =
+  process.env.GITHUB_SHA || execSync('git rev-parse HEAD').toString().trim();
+
+const versionOf = (file) => JSON.parse(readFileSync(file, 'utf8')).version;
+
+/** Returns the list of versions already published to npm (empty if unpublished). */
+function publishedVersions(name) {
+  try {
+    const out = execSync(`npm view ${name} versions --json`, {
+      stdio: ['ignore', 'pipe', 'ignore'],
+    })
+      .toString()
+      .trim();
+    if (!out) return [];
+    const parsed = JSON.parse(out);
+    return Array.isArray(parsed) ? parsed : [parsed];
+  } catch {
+    // E404 — the package has never been published.
+    return [];
+  }
+}
+
+function run(cmd) {
+  console.log(`  $ ${cmd}`);
+  if (DRY_RUN) return;
+  execSync(cmd, { stdio: 'inherit' });
+}
+
+let released = 0;
+let failed = false;
+
+console.log(`Release check @ ${sha.slice(0, 8)}${DRY_RUN ? ' (dry run)' : ''}\n`);
+
+for (const pkg of PACKAGES) {
+  const version = versionOf(pkg.versionFile);
+  const published = publishedVersions(pkg.name);
+
+  if (published.includes(version)) {
+    console.log(`✓ ${pkg.name}@${version} already on npm — skip`);
+    continue;
+  }
+
+  const latest = published.slice(-1)[0] || 'nothing';
+  console.log(`\n▲ ${pkg.label}: releasing ${pkg.name}@${version} (npm latest: ${latest})`);
+
+  try {
+    run(pkg.publish);
+    const tag = `${pkg.tagPrefix}-v${version}`;
+    const title = `${pkg.name} v${version}`;
+    // `gh release create` creates the tag at --target and the GitHub Release.
+    run(
+      `gh release create "${tag}" --target "${sha}" --title "${title}" --generate-notes`,
+    );
+    console.log(`✓ ${tag} published + released`);
+    released += 1;
+  } catch (err) {
+    console.error(`✗ ${pkg.name}@${version} failed: ${err.message}`);
+    failed = true;
+  }
+}
+
+console.log(
+  `\n${released} package(s) ${DRY_RUN ? 'would be ' : ''}released.` +
+    (released === 0 && !failed ? ' Nothing to do — all versions are current.' : ''),
+);
+
+if (failed) process.exit(1);


### PR DESCRIPTION
Adds npm publishing from CI and makes releases show up in the repo sidebar. Publishing was manual (`pnpm publish:lib`/`cli`/`mcp`) with no tags or GitHub Releases — the right-hand sidebar was empty.

## How it works
- New workflow [`.github/workflows/release.yml`](.github/workflows/release.yml) triggers when a version changes in any publishable `package.json` on `main` (path-filtered), or via **Run workflow**.
- It runs lint · typecheck · test · build, then [`scripts/release.mjs`](scripts/release.mjs):
  - compares each package version with npm,
  - **publishes only the new ones** (reusing the existing `publish:*` scripts),
  - creates a **GitHub Release + tag** per package (`components-vX.Y.Z`, `cli-vX.Y.Z`, `mcp-vX.Y.Z`) → fills the sidebar.
- **Idempotent**: versions already on npm are skipped, so re-running is safe.

Dry-run output (read-only):
```
✓ @voltui/components@0.6.0 already on npm — skip
▲ CLI: releasing @voltui/cli@0.6.0 (npm latest: 0.1.0)
✓ volt-ui-mcp@0.2.0 already on npm — skip
```

## Required before it can publish
Add an **`NPM_TOKEN`** repo secret (npm **Automation** token). Steps in [RELEASING.md](RELEASING.md).

## Notes
- Merging this PR does **not** publish anything (no `package.json` version changes here, so the path filter doesn't fire) — safe to merge.
- First real run (bump a version, or Run workflow manually) will also catch up `@voltui/cli` from `0.1.0` → `0.6.0`, which is currently behind on npm.
- Independent of PR #47 (README/deploy); branched from `main`, touches no shared files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)