### PR TITLE
chore(release): v0.8.1 — Select dropdown fix and component bug-fix patch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,70 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-08-02
+
+### Fixed
+
+- **Select dropdown mispositioning**: `volt-select-content` never bound `width:
+var(--ngp-select-width)` (the CSS variable ng-primitives exposes so the dropdown can
+  match the trigger's width — the sibling `combobox-dropdown` already does this
+  correctly). Without it, the panel sized itself to its content (~128px) instead of the
+  trigger's width, and floating-ui's default center-aligned `bottom` placement then
+  anchored the panel's left edge to the trigger's horizontal center, pushing most of the
+  panel outside the trigger's bounds. Fixed by binding the width (matching Combobox's
+  pattern) and switching `NgpSelect`'s placement to `bottom-start`, which aligns by the
+  trigger's left edge and doesn't depend on measuring the floating panel's width at all.
+- **`VoltBadge` silently dropping custom classes**: the component computed its host
+  `[class]` purely from `badgeVariants({variant})`, never merging in a caller-provided
+  `class` attribute through `cn()`/`twMerge` (every other component with variants —
+  `Button`, `Table*`, `Dialog`, etc. — does). A custom override like `text-background`
+  ended up sitting in the DOM next to the variant's own `text-foreground` with no
+  dedup; whichever utility Tailwind happened to generate later in the stylesheet won,
+  independent of the caller's intent. Added a `class` input merged via `cn()`, matching
+  the rest of the library.
+- **Self-referential layout demos showing every sidebar item as "active"**: the Sidebar
+  Layout and Admin Dashboard demo pages point every nav item at the same literal route
+  (they're single-page mockups), so Angular's `routerLinkActive` matched all of them
+  regardless of the `exact` input — every item rendered with the active/highlighted
+  style simultaneously. Added a `queryParams` input to `VoltSidebarItem` (forwarded to
+  `[queryParams]`, which Angular resolves as real query parameters, unlike embedding
+  `?query=` directly in the `routerLink` string) and gave each non-current demo item a
+  distinguishing value, so only the current item matches.
+- **Tabs active indicator invisible in dark mode**: `data-[state=active]` used
+  `bg-background`, which is _darker_ than the tab list's own `bg-muted` in the dark
+  palette (background 0.05 vs muted 0.15 lightness) — the "active" tab rendered as a
+  recessed patch rather than a raised one, distinguishable only by text color. Added a
+  `border-input` border to the active state, which reliably contrasts against both the
+  fill and the list background in every preset and mode.
+- **Docs pages leaking a native browser tooltip across the whole content area**: the
+  three docs shells (`Layouts`, `Components`, `Getting Started`) passed their `title` as
+  a plain string attribute (`title="Layouts"`) to `<app-docs-page-shell>`. Angular
+  applies a static string attribute to a matching component input _and_ leaves it as a
+  literal DOM attribute — since `title` is a global HTML attribute, this made the
+  browser show a native tooltip reading "Layouts"/"Components"/"Getting Started"
+  anywhere you hovered inside that shell (nav sidebar and the entire demo/content pane),
+  landing wherever the cursor happened to be. Switched to property binding
+  (`[title]="'Layouts'"`), which binds only the component input.
+- **Landing CTA section always inverting relative to the site theme**: the "Copy
+  components into your project" section used `bg-foreground text-background`
+  unconditionally, so in dark mode — where `--foreground` is light — it rendered as a
+  bright section in the middle of an otherwise dark page, defeating the point of dark
+  mode. Switched to `bg-muted`/`text-foreground`/`text-muted-foreground`, which respects
+  whichever theme is active like the rest of the page. The terminal mockup inside it
+  (intentionally always dark, `bg-black/40`) had its own text colored via
+  `text-background/*`, which depended on the same inversion; changed to fixed
+  `text-white/*` values since the terminal's background no longer flips with it.
+- **Hero heading crowding descenders**: `tracking-[-0.055em]` and `leading-[0.98]` on
+  the display heading were tight enough to crowd descenders (the 'y' in "you") against
+  the line above at large viewport widths. Loosened to `tracking-[-0.02em]` /
+  `leading-[1.05]`. Also added the `-webkit-background-clip`/`-webkit-text-fill-color`
+  pair to the animated gradient-text style, which some WebKit versions require for
+  `background-clip: text` to render at all during a `background-position` animation.
+
+### Changed
+
+- Bumped the root package, `@voltui/components`, and `@voltui/cli` to `0.8.1`.
+
 ## [0.8.0] - 2026-08-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -221,7 +221,7 @@ Volt UI ships three complementary ways to give AI assistants correct context:
 
 ## 📈 Stability & Roadmap
 
-Current status: **`0.8.0` — theme system audited to WCAG AA, docs completeness sweep.**
+Current status: **`0.8.1` — Select dropdown positioning fix and component bug-fix patch.**
 
 - **Stable** — recommended for early adoption.
 - **Beta** — usable; may still gain forms / keyboard / a11y / edge-case coverage.

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voltui/cli",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "CLI for adding Volt UI components to your project",
   "homepage": "https://volt-ui.andersseen.dev",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "volt-ui",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "bin": {
     "volt": "./cli/bin/volt",
     "volt-ui-mcp": "./cli/mcp/setup-mcp.js"

--- a/projects/volt/package.json
+++ b/projects/volt/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@voltui/components",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "Copy-and-own Angular components built with signals, Tailwind CSS v4 and ng-primitives.",
   "license": "MIT",
   "homepage": "https://volt-ui.andersseen.dev",

--- a/projects/volt/src/lib/components/badge/badge.ts
+++ b/projects/volt/src/lib/components/badge/badge.ts
@@ -1,4 +1,5 @@
 import { ChangeDetectionStrategy, Component, computed, input } from '@angular/core';
+import { cn } from '../../utils';
 import { badgeVariants, type BadgeVariants } from './variants';
 
 @Component({
@@ -11,6 +12,9 @@ import { badgeVariants, type BadgeVariants } from './variants';
 })
 export class VoltBadge {
   readonly variant = input<BadgeVariants['variant']>('solid');
+  readonly class = input<string>('');
 
-  protected readonly classes = computed(() => badgeVariants({ variant: this.variant() }));
+  protected readonly classes = computed(() =>
+    cn(badgeVariants({ variant: this.variant() }), this.class())
+  );
 }

--- a/projects/volt/src/lib/components/select/select-content.ts
+++ b/projects/volt/src/lib/components/select/select-content.ts
@@ -8,7 +8,7 @@ import { NgpSelectDropdown } from 'ng-primitives/select';
   template: `
     <div
       ngpSelectDropdown
-      class="absolute block z-50 min-w-[8rem] overflow-hidden rounded-md border border-border bg-surface text-surface-foreground shadow-md animate-in fade-in-80 zoom-in-95"
+      class="absolute block z-50 min-w-[var(--ngp-select-width)] max-w-[var(--ngp-select-width)] w-full overflow-hidden rounded-md border border-border bg-surface text-surface-foreground shadow-md animate-in fade-in-80 zoom-in-95"
     >
       <div class="p-1 w-full flex flex-col">
         <ng-content />

--- a/projects/volt/src/lib/components/select/select.ts
+++ b/projects/volt/src/lib/components/select/select.ts
@@ -31,6 +31,7 @@ import { injectFormControlState } from '../../form-control-state';
     <button
       ngpSelect
       type="button"
+      ngpSelectDropdownPlacement="bottom-start"
       [ngpSelectValue]="value()"
       [ngpSelectDisabled]="isDisabled()"
       [ngpSelectMultiple]="multiple()"

--- a/projects/volt/src/lib/components/tabs/tabs-trigger.ts
+++ b/projects/volt/src/lib/components/tabs/tabs-trigger.ts
@@ -7,7 +7,7 @@ import { NgpTabButton, injectTabButtonState, provideTabButtonState } from 'ng-pr
   providers: [provideTabButtonState()],
   host: {
     class:
-      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 cursor-pointer data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
+      'inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50 cursor-pointer data-[state=active]:border data-[state=active]:border-input data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm',
     '[attr.data-state]': "tabButtonState().active() ? 'active' : 'inactive'",
   },
   hostDirectives: [

--- a/projects/volt/src/lib/layouts/sidebar/sidebar.ts
+++ b/projects/volt/src/lib/layouts/sidebar/sidebar.ts
@@ -125,7 +125,8 @@ export class VoltSidebarGroup {
         [voltTooltip]="label()"
         placement="right"
         [routerLink]="routerLink()"
-        routerLinkActive="bg-accent text-accent-foreground font-medium"
+        [queryParams]="queryParams()"
+        routerLinkActive="bg-accent text-accent-foreground font-medium active"
         [routerLinkActiveOptions]="{ exact: exact() }"
         class="flex h-10 w-full items-center justify-center rounded-md text-muted-foreground transition-colors hover:text-foreground hover:bg-accent/50 group relative"
         (click)="sidebarService.setMobileOpen(false)"
@@ -138,6 +139,7 @@ export class VoltSidebarGroup {
     } @else {
       <a
         [routerLink]="routerLink()"
+        [queryParams]="queryParams()"
         routerLinkActive="bg-accent text-accent-foreground font-medium active"
         [routerLinkActiveOptions]="{ exact: exact() }"
         class="flex h-10 w-full items-center gap-3 rounded-md px-3 text-sm text-muted-foreground transition-colors hover:text-foreground hover:bg-accent/50 group relative"
@@ -152,6 +154,7 @@ export class VoltSidebarGroup {
 })
 export class VoltSidebarItem {
   readonly routerLink = input.required<string>();
+  readonly queryParams = input<Record<string, string> | undefined>(undefined);
   readonly label = input.required<string>();
   readonly exact = input<boolean, unknown>(false, { transform: booleanAttribute });
 

--- a/src/app/components/app-shell.spec.ts
+++ b/src/app/components/app-shell.spec.ts
@@ -22,7 +22,7 @@ describe('application shell', () => {
       'href',
       '/create-theme'
     );
-    expect(screen.getByText('v0.8.0')).toBeInTheDocument();
+    expect(screen.getByText('v0.8.1')).toBeInTheDocument();
   });
 
   it('renders useful footer navigation and repository metadata', async () => {

--- a/src/app/components/header.ts
+++ b/src/app/components/header.ts
@@ -44,7 +44,7 @@ import { LmnGithubIcon } from 'lumen-icons';
             variant="secondary"
             class="font-mono text-xs hidden md:inline-flex border-none shadow-sm ring-1 ring-border/50"
           >
-            v0.8.0
+            v0.8.1
           </volt-badge>
         </div>
 

--- a/src/app/lib/api-reference.generated.ts
+++ b/src/app/lib/api-reference.generated.ts
@@ -87,7 +87,10 @@ export const BADGE_API: ComponentApi = {
     {
       className: 'VoltBadge',
       selector: 'volt-badge',
-      inputs: [{ name: 'variant', type: "BadgeVariants['variant']", default: "'solid'" }],
+      inputs: [
+        { name: 'variant', type: "BadgeVariants['variant']", default: "'solid'" },
+        { name: 'class', type: 'string', default: "''" },
+      ],
       outputs: [],
     },
   ],
@@ -1223,6 +1226,7 @@ export const SIDEBAR_API: ComponentApi = {
       inputs: [
         { name: 'label', type: 'string' },
         { name: 'routerLink', type: 'string', required: true },
+        { name: 'queryParams', type: 'Record<string, string> | undefined', default: 'undefined' },
         { name: 'exact', type: 'boolean', default: 'false', transform: 'booleanAttribute' },
       ],
       outputs: [],

--- a/src/app/pages/(components-docs).page.ts
+++ b/src/app/pages/(components-docs).page.ts
@@ -9,7 +9,7 @@ import { COMPONENT_GROUPS } from '../lib/component-metadata';
   changeDetection: ChangeDetectionStrategy.OnPush,
   imports: [RouterOutlet, DocsPageShell],
   template: `
-    <app-docs-page-shell title="Components" browseLabel="Browse Components" [groups]="groups">
+    <app-docs-page-shell [title]="'Components'" browseLabel="Browse Components" [groups]="groups">
       <router-outlet />
     </app-docs-page-shell>
   `,

--- a/src/app/pages/(getting-started).page.ts
+++ b/src/app/pages/(getting-started).page.ts
@@ -9,7 +9,7 @@ import type { DocsSidebarGroup } from '../components/docs-sidebar-nav';
   imports: [RouterOutlet, DocsPageShell],
   template: `
     <app-docs-page-shell
-      title="Getting Started"
+      [title]="'Getting Started'"
       browseLabel="Browse Documentation"
       [groups]="groups"
     >

--- a/src/app/pages/(layouts-docs).page.ts
+++ b/src/app/pages/(layouts-docs).page.ts
@@ -9,7 +9,7 @@ import type { DocsSidebarGroup } from '../components/docs-sidebar-nav';
   imports: [RouterOutlet, DocsPageShell],
   template: `
     <app-docs-page-shell
-      title="Layouts"
+      [title]="'Layouts'"
       browseLabel="Browse Layouts"
       description="Copy-paste blocks. No install needed."
       [groups]="groups"

--- a/src/app/pages/(layouts-docs)/docs/layouts/admin-dashboard.page.ts
+++ b/src/app/pages/(layouts-docs)/docs/layouts/admin-dashboard.page.ts
@@ -103,7 +103,11 @@ import {
             >
               <lmn-home slot="icon" class="h-4 w-4" />
             </volt-sidebar-item>
-            <volt-sidebar-item routerLink="/docs/layouts/admin-dashboard" label="Analytics">
+            <volt-sidebar-item
+              routerLink="/docs/layouts/admin-dashboard"
+              [queryParams]="{ tab: 'analytics' }"
+              label="Analytics"
+            >
               <lmn-grid slot="icon" class="h-4 w-4" />
             </volt-sidebar-item>
           </volt-sidebar-group>
@@ -113,10 +117,18 @@ import {
           </div>
 
           <volt-sidebar-group label="Management">
-            <volt-sidebar-item routerLink="/docs/layouts/admin-dashboard" label="Users">
+            <volt-sidebar-item
+              routerLink="/docs/layouts/admin-dashboard"
+              [queryParams]="{ tab: 'users' }"
+              label="Users"
+            >
               <lmn-avatar slot="icon" class="h-4 w-4" />
             </volt-sidebar-item>
-            <volt-sidebar-item routerLink="/docs/layouts/admin-dashboard" label="Messages">
+            <volt-sidebar-item
+              routerLink="/docs/layouts/admin-dashboard"
+              [queryParams]="{ tab: 'messages' }"
+              label="Messages"
+            >
               <lmn-mail slot="icon" class="h-4 w-4" />
               <div
                 slot="trailing"
@@ -125,7 +137,11 @@ import {
                 12
               </div>
             </volt-sidebar-item>
-            <volt-sidebar-item routerLink="/docs/layouts/admin-dashboard" label="Settings">
+            <volt-sidebar-item
+              routerLink="/docs/layouts/admin-dashboard"
+              [queryParams]="{ tab: 'settings' }"
+              label="Settings"
+            >
               <lmn-settings slot="icon" class="h-4 w-4" />
             </volt-sidebar-item>
           </volt-sidebar-group>

--- a/src/app/pages/(layouts-docs)/docs/layouts/sidebar.page.ts
+++ b/src/app/pages/(layouts-docs)/docs/layouts/sidebar.page.ts
@@ -93,7 +93,11 @@ import { SIDEBAR_USAGE } from '../../../../lib/snippets/usage';
             <volt-sidebar-item routerLink="/docs/layouts/sidebar" [exact]="true" label="Dashboard">
               <lmn-home slot="icon" class="h-4 w-4" />
             </volt-sidebar-item>
-            <volt-sidebar-item routerLink="/docs/layouts/sidebar" label="Inbox">
+            <volt-sidebar-item
+              routerLink="/docs/layouts/sidebar"
+              [queryParams]="{ tab: 'inbox' }"
+              label="Inbox"
+            >
               <lmn-mail slot="icon" class="h-4 w-4" />
               <div
                 slot="trailing"
@@ -102,7 +106,11 @@ import { SIDEBAR_USAGE } from '../../../../lib/snippets/usage';
                 3
               </div>
             </volt-sidebar-item>
-            <volt-sidebar-item routerLink="/docs/layouts/sidebar" label="Components">
+            <volt-sidebar-item
+              routerLink="/docs/layouts/sidebar"
+              [queryParams]="{ tab: 'components' }"
+              label="Components"
+            >
               <lmn-grid slot="icon" class="h-4 w-4" />
             </volt-sidebar-item>
           </volt-sidebar-group>
@@ -113,13 +121,25 @@ import { SIDEBAR_USAGE } from '../../../../lib/snippets/usage';
 
           <!-- Secondary Group -->
           <volt-sidebar-group label="Configuration">
-            <volt-sidebar-item routerLink="/docs/layouts/sidebar" label="Profile">
+            <volt-sidebar-item
+              routerLink="/docs/layouts/sidebar"
+              [queryParams]="{ tab: 'profile' }"
+              label="Profile"
+            >
               <lmn-avatar slot="icon" class="h-4 w-4" />
             </volt-sidebar-item>
-            <volt-sidebar-item routerLink="/docs/layouts/sidebar" label="Settings">
+            <volt-sidebar-item
+              routerLink="/docs/layouts/sidebar"
+              [queryParams]="{ tab: 'settings' }"
+              label="Settings"
+            >
               <lmn-settings slot="icon" class="h-4 w-4" />
             </volt-sidebar-item>
-            <volt-sidebar-item routerLink="/docs/layouts/sidebar" label="Search">
+            <volt-sidebar-item
+              routerLink="/docs/layouts/sidebar"
+              [queryParams]="{ tab: 'search' }"
+              label="Search"
+            >
               <lmn-search slot="icon" class="h-4 w-4" />
             </volt-sidebar-item>
           </volt-sidebar-group>

--- a/src/app/pages/index.page.ts
+++ b/src/app/pages/index.page.ts
@@ -71,7 +71,7 @@ import {
           </volt-badge>
 
           <h1
-            class="reveal-up reveal-delay-1 mt-7 text-balance text-5xl font-bold tracking-[-0.055em] sm:text-7xl lg:text-[5.5rem] lg:leading-[0.98]"
+            class="reveal-up reveal-delay-1 mt-7 text-balance text-5xl font-bold tracking-[-0.02em] sm:text-7xl lg:text-[5.5rem] lg:leading-[1.05]"
           >
             Angular components
             <span class="electric-text">you actually own.</span>
@@ -303,22 +303,19 @@ import {
         </div>
       </section>
 
-      <section class="border-y border-border/60 bg-foreground text-background">
+      <section class="border-y border-border/60 bg-muted">
         <div
           class="mx-auto grid max-w-6xl items-center gap-14 px-4 py-20 sm:px-6 lg:grid-cols-2 lg:py-28"
         >
           <div>
-            <volt-badge
-              variant="outline"
-              class="border-background/20 bg-background/10 text-background"
-            >
+            <volt-badge variant="outline">
               <lmn-zap [size]="12" class="mr-1.5" />
               One command. Your source.
             </volt-badge>
             <h2 class="mt-6 text-balance text-3xl font-semibold tracking-tight sm:text-5xl">
               Copy components into your project, not another black box.
             </h2>
-            <p class="mt-5 max-w-xl text-lg leading-8 text-background/65">
+            <p class="mt-5 max-w-xl text-lg leading-8 text-muted-foreground">
               The CLI resolves component dependencies, adapts selectors, and leaves readable Angular
               source in your repository.
             </p>
@@ -326,27 +323,25 @@ import {
               routerLink="/docs/introduction"
               variant="outline"
               size="lg"
-              class="mt-8 rounded-full border-background/20 bg-background text-foreground hover:bg-background/90"
+              class="mt-8 rounded-full"
             >
               Read the installation guide
               <lmn-arrow-right slot="trailing" [size]="16" />
             </volt-button>
           </div>
 
-          <div
-            class="overflow-hidden rounded-2xl border border-background/15 bg-black/40 shadow-2xl"
-          >
-            <div class="flex items-center gap-2 border-b border-background/10 px-4 py-3">
+          <div class="overflow-hidden rounded-2xl border border-white/15 bg-black/40 shadow-2xl">
+            <div class="flex items-center gap-2 border-b border-white/10 px-4 py-3">
               <span class="h-2.5 w-2.5 rounded-full bg-red-400"></span>
               <span class="h-2.5 w-2.5 rounded-full bg-amber-300"></span>
               <span class="h-2.5 w-2.5 rounded-full bg-emerald-400"></span>
-              <span class="ml-auto font-mono text-[10px] text-background/40">terminal</span>
+              <span class="ml-auto font-mono text-[10px] text-white/40">terminal</span>
             </div>
-            <div class="space-y-4 p-5 font-mono text-xs sm:p-7 sm:text-sm">
+            <div class="space-y-4 p-5 font-mono text-xs text-white sm:p-7 sm:text-sm">
               <p><span class="text-emerald-400">➜</span> npx &#64;voltui/cli init</p>
-              <p class="text-background/50">✓ Tailwind tokens configured</p>
+              <p class="text-white/50">✓ Tailwind tokens configured</p>
               <p><span class="text-emerald-400">➜</span> npx &#64;voltui/cli add dialog</p>
-              <div class="space-y-1 border-l border-background/15 pl-4 text-background/55">
+              <div class="space-y-1 border-l border-white/15 pl-4 text-white/55">
                 <p>create src/app/ui/dialog/dialog.ts</p>
                 <p>create src/app/ui/button/button.ts</p>
                 <p>update src/app/ui/index.ts</p>
@@ -424,6 +419,8 @@ import {
       background: linear-gradient(115deg, var(--primary), oklch(0.72 0.18 300), var(--primary));
       background-size: 200% auto;
       background-clip: text;
+      -webkit-background-clip: text;
+      -webkit-text-fill-color: transparent;
       animation: electric-shift 7s linear infinite;
     }
 


### PR DESCRIPTION
- Select: dropdown panel now matches the trigger's width and left edge (was centering on the trigger's midpoint using an unset width, pushing the panel outside the trigger's bounds). Bound width to --ngp-select-width and switched to bottom-start placement.
- Badge: custom `class` overrides were never merged with the variant's own classes (no cn()), so caller overrides silently lost to whichever utility Tailwind emitted later. Added a merged `class` input.
- Sidebar layout demos (Sidebar Layout, Admin Dashboard): every nav item pointed at the same route, so routerLinkActive matched all of them at once. Added a `queryParams` input to VoltSidebarItem and gave each non-current demo item a distinguishing value.
- Tabs: active tab was indistinguishable in dark mode (bg-background is darker than the list's bg-muted there). Added a border-input border.
- Docs shells (Layouts/Components/Getting Started): a plain `title="..."` attribute leaked as a native browser tooltip across the whole content area. Switched to a property binding.
- Landing CTA section always inverted relative to the active theme, showing a bright band in the middle of a dark-mode page. Now respects the current theme; terminal mockup text no longer depends on it.
- Hero heading: loosened tracking/line-height that crowded descenders, added -webkit- gradient-text prefixes for WebKit correctness.

Bumped root, @voltui/components, and @voltui/cli to 0.8.1 in lockstep (cli/mcp versioned independently, unchanged). pnpm release:check green: lint, typecheck, check:ai-docs, test:coverage (88.37%/60.06%/82.23%/87.78%), pack:lib/cli/mcp all pass.

## Summary

<!-- What changes, and why? -->

## Verification

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm check:ai-docs`
- [ ] `pnpm test:coverage`
- [ ] Relevant E2E tests
- [ ] Docs/snippets/manifest updated when public APIs changed

## Accessibility

<!-- Describe keyboard, focus, semantics and screen-reader impact, or N/A. -->
